### PR TITLE
Rotated traces

### DIFF
--- a/grismconf/__init__.py
+++ b/grismconf/__init__.py
@@ -1,1 +1,2 @@
-from grismconf import *
+from .grismconf import Config
+#from . import poly

--- a/grismconf/grismconf.py
+++ b/grismconf/grismconf.py
@@ -110,7 +110,7 @@ class Config(object):
             if fs(l)>0:
                 overlap = 1
         if overlap==0:
-            print "Sensitivity and filter passband do not ovelap. Check units..."
+            print("Sensitivity and filter passband do not ovelap. Check units...")
         
         self.SENS_data[order][1] = np.asarray(ys)
         self.SENS_data[order][0] = np.asarray(xs)
@@ -206,7 +206,7 @@ class Config(object):
             if len(ws)>0 and str in ws[0]:
                 i = int(ws[0].split(str)[-1])
                 if len(ws)-1 !=m:
-                    print "Wrong format for ",GRISM_CONF,name,order
+                    print("Wrong format for ",GRISM_CONF,name,order)
                     sys.exit(10)
                 vals = [float(ww) for ww in ws[1:]]
                 arr[i,0:m] = vals

--- a/grismconf/grismconf.py
+++ b/grismconf/grismconf.py
@@ -1,4 +1,4 @@
-import poly
+from . import poly
 import numpy as np 
 import os
 from astropy.io import fits
@@ -19,13 +19,11 @@ class interp1d_picklable:
     def __call__(self, xnew):
         return self.f(xnew)
 
-    def __getstate__(self):
+    def _getstate__(self):
         return self.xi, self.yi, self.args
 
     def __setstate__(self, state):
         self.f = interp1d(state[0], state[1], **state[2])
-
-
 
 class Config(object):
     """Class to read and hold GRISM configuration info"""
@@ -33,16 +31,17 @@ class Config(object):
         """Read in Grism Configuration file and populate various things"""
         self.__version__=__version__
         self.GRISM_CONF = open(GRISM_CONF).readlines()
-        self.GRISM_CONF_PATH = os.path.split(GRISM_CONF)[0]
+        self.GRISM_CONF_PATH = os.path.dirname(GRISM_CONF)
+        self.GRISM_CONF_FILE = os.path.basename(GRISM_CONF)
 
-        self.orders = self.__get_orders()
-        self.DISPX_DATA = {}
-        self.DISPY_DATA = {}
-        self.DISPL_DATA = {}
+        self.orders = self._get_orders()
+        self._DISPX_data = {}
+        self._DISPY_data = {}
+        self._DISPL_data = {}
 
-        self.DISPX_POLYNAME = {}
-        self.DISPY_POLYNAME = {}
-        self.DISPL_POLYNAME = {}
+        self._DISPX_polyname = {}
+        self._DISPY_polyname = {}
+        self._DISPL_polyname = {}
 
         self.SENS = {}
         self.SENS_data = {}
@@ -56,7 +55,7 @@ class Config(object):
 
         if DIRFILTER!=None:
             # We get the wedge offset values for this direct filter
-            r = self.__get_value("WEDGE_%s" % (DIRFILTER),type=float)
+            r = self._get_value("WEDGE_%s" % (DIRFILTER),type=float)
             self.wx = r[0]
             self.wy = r[1]
         else:
@@ -64,16 +63,16 @@ class Config(object):
             self.wy = 0.
 
         for order in self.orders:    
-            self.DISPX_DATA[order] = self.__get_parameters("DISPX",order)
-            self.DISPY_DATA[order] = self.__get_parameters("DISPY",order)
-            self.DISPL_DATA[order] = self.__get_parameters("DISPL",order)
-            self.SENS[order] = self.__get_sensitivity(order)
+            self._DISPX_data[order] = self._get_parameters("DISPX",order)
+            self._DISPY_data[order] = self._get_parameters("DISPY",order)
+            self._DISPL_data[order] = self._get_parameters("DISPL",order)
+            self.SENS[order] = self._get_sensitivity(order)
             
-            self.DISPX_POLYNAME[order] = np.shape(self.DISPX_DATA[order])
-            self.DISPY_POLYNAME[order] = np.shape(self.DISPY_DATA[order])
-            self.DISPL_POLYNAME[order] = np.shape(self.DISPL_DATA[order])
+            self._DISPX_polyname[order] = np.shape(self._DISPX_data[order])
+            self._DISPY_polyname[order] = np.shape(self._DISPY_data[order])
+            self._DISPL_polyname[order] = np.shape(self._DISPL_data[order])
 
-            self.SENS_data[order] = self.__get_sensitivity(order)
+            self.SENS_data[order] = self._get_sensitivity(order)
 
             wmin = np.min(self.SENS_data[order][0][self.SENS_data[order][1]!=0])
             wmax = np.max(self.SENS_data[order][0][self.SENS_data[order][1]!=0])
@@ -81,21 +80,21 @@ class Config(object):
  
             if cross_filter!=None:
                 # get name of filter bandpass from config file
-                filter_filename = self.__get_value("FILTER_%s" % (cross_filter))
+                filter_filename = self._get_value("FILTER_%s" % (cross_filter))
                 filter_filename = os.path.join(self.GRISM_CONF_PATH,filter_filename)
                 passband_tab = Table.read(filter_filename,format="ascii.no_header",data_start=1)
                 # Convert bandpass to angstrom
                 passband_tab['col1'] = passband_tab['col1']*10000
-                self.__apply_passband(order,passband_tab,threshold=1e-4)
+                self._apply_passband(order,passband_tab,threshold=1e-4)
 
 #            if not pool:
             self.SENS[order] = interp1d_picklable(self.SENS_data[order][0],self.SENS_data[order][1],bounds_error=False,fill_value=0.)
 
             
-            self.XRANGE[order] = self.__get_value("XRANGE_%s" % (order),type=float)
-            self.YRANGE[order] = self.__get_value("YRANGE_%s" % (order),type=float)
+            self.XRANGE[order] = self._get_value("XRANGE_%s" % (order),type=float)
+            self.YRANGE[order] = self._get_value("YRANGE_%s" % (order),type=float)
 
-    def __apply_passband(self,order,passband_tab,threshold):
+    def _apply_passband(self,order,passband_tab,threshold):
         """A helper function that applies an additional passband to the existing sensitivity. This modifies self.SENS_data and also recompute the interpolation function stored in self.SENS"""
 
         # Apply grism sensitibity to filter... i.e. use filter as wavelength basis
@@ -124,46 +123,157 @@ class Config(object):
 
         return
 
+    @staticmethod
+    def _rotate_coords(dx, dy, theta=0, origin=[0,0]):
+        """Rotate cartesian coordinates CW about an origin
+        
+        Parameters
+        ----------
+        dx, dy : float or `~numpy.ndarray`
+            x and y coordinages
+                    
+        theta : float
+            CW rotation angle, in radians
+            
+        origin : [float,float]
+            Origin about which to rotate
+        
+        Returns
+        -------
+        dxr, dyr : float or `~numpy.ndarray`
+            Rotated versions of `dx` and `dy`
+            
+        """
+        _mat = np.array([[np.cos(theta), -np.sin(theta)],
+                     [np.sin(theta), np.cos(theta)]])
 
-
+        rot = np.dot(np.array([dx-origin[0], dy-origin[1]]).T, _mat)
+        dxr = rot[:,0]+origin[0]
+        dyr = rot[:,1]+origin[1]
+        return dxr, dyr
+        
     def DISPL(self,order,x0,y0,t):
         """DISPL() returns the wavelength l = DISPL(x0,y0,t) where x0,y0 is the 
         position on the detector and 0<t<1"""
-        return poly.POLY[self.DISPL_POLYNAME[order]](self.DISPL_DATA[order],x0,y0,t)
+        return poly.POLY[self._DISPL_polyname[order]](self._DISPL_data[order],x0,y0,t)
 
     def DDISPL(self,order,x0,y0,t):
         """DDISPL returns the wavelength 1st derivative with respect to t  l =  d(DISPL(x0,y0,t))/dt where x0,y0 is the position on the detector and 0<t<1"""
-        return poly.DPOLY[self.DISPL_POLYNAME[order]](self.DISPL_DATA[order],x0,y0,t)
+        return poly.DPOLY[self._DISPL_polyname[order]](self._DISPL_data[order],x0,y0,t)
 
-    def DISPX(self,order,x0,y0,t):
+    def DISPXY(self, order, x0, y0, t, theta=0):
+        """Return both `x` and `y` coordinates of a rotated trace
+        
+        Parameters
+        ----------
+        order : str
+            Order string
+            
+        x0, y0 : float
+            Reference position (i.e., in direct image)
+
+        t : float or `~numpy.ndarray`
+            Parameter where to evaluate the trace
+            
+        theta : float
+            CW rotation angle, in radians
+        
+        Returns
+        -------
+        dxr, dyr : float or `~np.ndarray`
+            Rotated trace coordinates as a function of `t`
+
+        """
+        dx = -self.wx + poly.POLY[self._DISPX_polyname[order]](self._DISPX_data[order],x0,y0,t)
+        dy = -self.wy + poly.POLY[self._DISPY_polyname[order]](self._DISPY_data[order],x0,y0,t)
+
+        if theta != 0:
+            dxr, dyr = self._rotate_coords(dx, dy, theta=theta, origin=[0,0])
+            return dxr, dyr
+        else:
+            return dx, dy
+            
+    
+    def INVDISPXY(self, order, x0, y0, dx=None, dy=None, theta=0, t0=np.linspace(0,1,10)):
+        """Return independent variable `t` along rotated trace
+        
+        Parameters
+        ----------
+        order : str
+            Order string
+            
+        x0, y0 : float
+            Reference position (i.e., in direct image)
+
+        dx : float, `~numpy.ndarray` or None
+            `x` coordinate in *rotated* trace where to evaluate the trace
+            independent variable `t`.
+            
+        dy : float, `~numpy.ndarray` or None
+            Same as `dx` but evaluate along 'y' axis.
+        
+        t0 : `~np.ndarray`
+            Independent variable location where to evaluate the rotated trace.
+            For low-order trace shapes, this can be coarsely sampled as 
+            in the default.
+            
+        Returns
+        -------
+        tr : float or `~np.ndarray`
+            Independent variable `t` evaluated on the rotated trace at
+            `dx` or `dy`.
+
+        .. note::
+        
+        Order of execution is first check if `dx` supplied.  If not, then
+        check `dy`.  And if both are None, then return None (do nothing).
+        
+        """
+        if dx is not None:
+            xr, yr = self.DISPXY(order, x0, y0, t0, theta=theta)
+            so = np.argsort(xr)
+            tr = np.interp(dx, xr[so], t0[so])
+            return tr
+        
+        if dy is not None:
+            xr, yr = self.DISPXY(order, x0, y0, t0, theta=theta)
+            so = np.argsort(yr)
+            tr = np.interp(dy, yr[so], t0[so])
+            return tr
+                 
+        return None
+        
+    def DISPX(self,order,x0,y0,t,theta=0):
         """DISPX() eturns the x offset x'-x = DISPL(x0,y0,t) where x0,y0 is the 
         position on the detector, x'-x is the difference between direct and grism image x-coordinates and 0<t<1"""
-        return  -self.wx + poly.POLY[self.DISPX_POLYNAME[order]](self.DISPX_DATA[order],x0,y0,t)
+        dx = -self.wx + poly.POLY[self._DISPX_polyname[order]](self._DISPX_data[order],x0,y0,t)
+            
+        return  dx
 
     def DDISPX(self,order,x0,y0,t):
         """DDISPX returns the  1st derivative of DISPX() with respect to t  d(x'-x)/dt =  d(DISPX(x0,y0,t))/dt where x0,y0 is the position on the detector and 0<t<1"""
-        return  poly.DPOLY[self.DISPX_POLYNAME[order]](self.DISPX_DATA[order],x0,y0,t)
+        return  poly.DPOLY[self._DISPX_polyname[order]](self._DISPX_data[order],x0,y0,t)
 
     def DISPY(self,order,x0,y0,t):
         """DISPY() eturns the x offset 'y-y = DISPL(x0,y0,t) where x0,y0 is the 
         position on the detector, y'-y is the difference between direct and grism image y-coordinates and 0<t<1"""
-        return  -self.wy + poly.POLY[self.DISPY_POLYNAME[order]](self.DISPY_DATA[order],x0,y0,t)
+        return  -self.wy + poly.POLY[self._DISPY_polyname[order]](self._DISPY_data[order],x0,y0,t)
 
     def DDISPY(self,order,x0,y0,t):
         """DDISPY returns the  1st derivative of DISPY() with respect to t  d(y'-y)/dt =  d(DISPY(x0,y0,t))/dt where x0,y0 is the position on the detector and 0<t<1"""
-        return poly.DPOLY[self.DISPY_POLYNAME[order]](self.DISPY_DATA[order],x0,y0,t)
+        return poly.DPOLY[self._DISPY_polyname[order]](self._DISPY_data[order],x0,y0,t)
 
     def INVDISPL(self,order,x0,y0,l):
         """INVDISL() returns the t values corresponding to a given wavelength l, t = INVDISPL(x0,y0,l)"""
-        return poly.INVPOLY[self.DISPL_POLYNAME[order]](self.DISPL_DATA[order],x0,y0,l)
+        return poly.INVPOLY[self._DISPL_polyname[order]](self._DISPL_data[order],x0,y0,l)
 
     def INVDISPX(self,order,x0,y0,dx):
         """INVDISPX returns the x value corresponding to a given wavelength l, t = INVDISPL(x0,y0,l)"""
-        return poly.INVPOLY[self.DISPX_POLYNAME[order]](self.DISPX_DATA[order],x0,y0,dx+self.wx)
+        return poly.INVPOLY[self._DISPX_polyname[order]](self._DISPX_data[order],x0,y0,dx+self.wx)
 
     def INVDISPY(self,order,x0,y0,dy):
         """INVDISPY returns the y value corresponding to a given wavelength l, t = INVDISPL(x0,y0,l)"""
-        return poly.INVPOLY[self.DISPY_POLYNAME[order]](self.DISPY_DATA[order],x0,y0,dy+self.wy)    
+        return poly.INVPOLY[self._DISPY_polyname[order]](self._DISPY_data[order],x0,y0,dy+self.wy)    
 
     #def DLDX(self,order,x0,y0,t):
     #    return self.DDISPL(order,x0,y0,t)/self.DDISPX(order,x0,y0,t)
@@ -171,7 +281,7 @@ class Config(object):
     #def DLDY(self,order,x0,y0,t):
     #    return self.DDISPL(order,x0,y0,t)/self.DDISPY(order,x0,y0,t)
 
-    def __get_orders(self):
+    def _get_orders(self):
         """A helper function that parses the config file and finds all the Orders/BEAMS.
         Simply looks for the BEAM_ keywords"""
         orders = []
@@ -185,7 +295,7 @@ class Config(object):
                 orders.append(order)
         return orders
 
-    def __get_parameters(self,name,order,str_fmt="%s_%s_"):
+    def _get_parameters(self,name,order,str_fmt="%s_%s_"):
         """Return the 2D polynomial array stored in the config file"""
         str = str_fmt % (name,order)
         # Find out how many we have to store
@@ -213,7 +323,7 @@ class Config(object):
 
         return arr            
 
-    def __get_value(self,str,type=None):
+    def _get_value(self,str,type=None):
         """Helper function to simply return the value for a simple keyword parameters
         in the config file."""
         
@@ -234,10 +344,10 @@ class Config(object):
         return None
 
 
-    def __get_sensitivity(self,order):
+    def _get_sensitivity(self,order):
         """Helper function that looks for the name of the sensitivity file, reads it and
         stores the content in a simple list [WAVELENGTH, SENSITIVITY]."""
-        fname = os.path.join(self.GRISM_CONF_PATH,self.__get_value("SENSITIVITY_%s" % (order)))
+        fname = os.path.join(self.GRISM_CONF_PATH,self._get_value("SENSITIVITY_%s" % (order)))
         fin = fits.open(fname)
         wavs = fin[1].data.field("WAVELENGTH")[:]
         sens = fin[1].data.field("SENSITIVITY")[:]

--- a/grismconf/poly.py
+++ b/grismconf/poly.py
@@ -108,9 +108,9 @@ def test(n,m):
 	y = 100.
 
 	d = POLY[(n,m)](e,x,y,0.)
-	print "d:",d
+	print("d:",d)
 	t = INVPOLY[(n,m)](e,x,y,d)
-	print "t:",t
+	print("t:",t)
 
 if __name__=="__main__":
 	test(1,0)


### PR DESCRIPTION
I added code for rotating the traces à la NIRISS.  The forward method `DISPXY` simply applies a Cartesian rotation of the DISPX and DISPY results with the `_rotate_coords` method.  The inverse method `INVDISPXY` does not use the inverse polynomials but rather is an approximation using the following:

1. Compute the rotated trace (`xr`, `yr`) with `DISPXY` for a coarse grid of `t0` (a keyword with a valid default array).
2. Interpolate `t0(xr)` at the desired output `dx` in the rotated frame.  (I implemented both `dx` and `dy` in this single method).

The other changes with this pull request are renaming the attributes like `DISPX_DATA` to private attributes like `_DISPX_data`, so they're more easily distinguished from the methods like `DISPX`.  The private methods `__*` are also renamed to `_*`, e.g., `_get_orders`.

Finally, I added a `GRISM_CONF_FILE` attribute for the filename itself. 